### PR TITLE
Prevent adding placeholder to non CMS page

### DIFF
--- a/app/code/MentionMe/MentionMe/Plugin/Magento/Checkout/Controller/Onepage/SuccessPlugin.php
+++ b/app/code/MentionMe/MentionMe/Plugin/Magento/Checkout/Controller/Onepage/SuccessPlugin.php
@@ -35,6 +35,11 @@ class SuccessPlugin
      */
     public function afterExecute(Success $subject, $result)
     {
+        // Prevent adding placeholder to non CMS page result
+        if (!$result instanceof \Magento\Framework\View\Result\Page) {
+            return $result;
+        }
+
         // Only continue if this integration is enabled
         if ($this->dataHelper->getReferrerEnabled() == false) {
             return $result;

--- a/app/code/MentionMe/MentionMe/etc/module.xml
+++ b/app/code/MentionMe/MentionMe/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MentionMe_MentionMe" setup_version="1.0.6">
+    <module name="MentionMe_MentionMe" setup_version="1.0.7">
         <sequence>
         </sequence>
     </module>


### PR DESCRIPTION
Similar to the logic in the IndexPlugin we need to do a check to make sure the page is a CMS on before trying to add the script: 
https://github.com/mention-me/magento2-integration/blob/a4be799e2ca99b9c7bb703972b54c5bae9f876d3/app/code/MentionMe/MentionMe/Plugin/Magento/Cms/Controller/Index/IndexPlugin.php#L46