### PR TITLE
Substract shipping and VAT from order_total

### DIFF
--- a/app/code/MentionMe/MentionMe/Model/UrlBuilder/Referrer.php
+++ b/app/code/MentionMe/MentionMe/Model/UrlBuilder/Referrer.php
@@ -28,7 +28,7 @@ class Referrer extends AbstractUrlBuilder
             'customer_id' => $order->getCustomerId(),
             'segment' => $customerGroupName,
             'order_number' => $order->getIncrementId(),
-            'order_total' => $order->getSubtotal() - abs($order->getDiscountAmount()),
+            'order_total' => $order->getSubtotal() - abs($order->getDiscountAmount()) - abs($order->getShippingAmount())- abs($order->getCustomerTaxvat()),
             'order_currency' => $order->getOrderCurrencyCode(),
             'coupon_code' => $order->getCouponCode(),
             'locale' => $this->paramsHelper->getLocale(),

--- a/app/code/MentionMe/MentionMe/Model/UrlBuilder/Referrer.php
+++ b/app/code/MentionMe/MentionMe/Model/UrlBuilder/Referrer.php
@@ -28,7 +28,7 @@ class Referrer extends AbstractUrlBuilder
             'customer_id' => $order->getCustomerId(),
             'segment' => $customerGroupName,
             'order_number' => $order->getIncrementId(),
-            'order_total' => $order->getSubtotal() - abs($order->getDiscountAmount()) - abs($order->getShippingAmount())- abs($order->getCustomerTaxvat()),
+            'order_total' => $order->getSubtotal() - abs($order->getDiscountAmount()) - abs($order->getShippingAmount()) - abs($order->getCustomerTaxvat()),
             'order_currency' => $order->getOrderCurrencyCode(),
             'coupon_code' => $order->getCouponCode(),
             'locale' => $this->paramsHelper->getLocale(),


### PR DESCRIPTION
Testing notes:

Place test order on http://52.210.222.166/ and check if shipping cost and VAT is substracted.
I've tested this and Shipping cost is substracted... VAT doesn't seem to be added, need to look at enabling that on our demo and testing that as well