### PR TITLE
Create acl.xml

### DIFF
--- a/app/code/MentionMe/MentionMe/etc/acl.xml
+++ b/app/code/MentionMe/MentionMe/etc/acl.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="MentionMe_MentionMe::config" title="MentionMe settings" translate="title" sortOrder="10" />
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
Hi, currently there is `acl.xml` file missing, so MentionMe tab is visible only for admin users with "All resources" granted. 
Limited roles cannot be granted this permissions. This PR adds respective file and new rule is added.
Resource is referenced here:
https://github.com/mention-me/magento2-integration/blob/master/app/code/MentionMe/MentionMe/etc/adminhtml/system.xml#L12

![image](https://user-images.githubusercontent.com/511845/152340197-3ef779d4-9fdb-4c16-bccf-9b6891d3e0c0.png)
