### PR TITLE
Added firstname and surname to dashboard tag

### DIFF
--- a/app/code/MentionMe/MentionMe/Model/UrlBuilder/Dashboard.php
+++ b/app/code/MentionMe/MentionMe/Model/UrlBuilder/Dashboard.php
@@ -29,12 +29,24 @@ class Dashboard extends AbstractUrlBuilder
     {
         return [
             'locale' => $this->paramsHelper->getLocale(),
-            'situation' => self::SITUATION
+            'situation' => self::SITUATION,
+            'firstname' => $this->getCustomerFirstname(),
+            'surname' => $this->getCustomerLastname(),
         ];
     }
 
     private function getCustomerEmail()
     {
         return $this->paramsHelper->getCurrentCustomer()->getEmail();
+    }
+
+    private function getCustomerFirstName()
+    {
+        return $this->paramsHelper->getCurrentCustomer()->getFirstname();
+    }
+
+    private function getCustomerLastName()
+    {
+        return $this->paramsHelper->getCurrentCustomer()->getLastname();
     }
 }


### PR DESCRIPTION
Marta raised this issue that the dashboard tag is not being populated with firstname and surname. 
This adds the 2 query parameters for `firstname` and `surname` to the tag.