### PR TITLE
Mirror reviewer to assignee

### DIFF
--- a/.github/workflows/mirror-reviewer-to-assignee.yml
+++ b/.github/workflows/mirror-reviewer-to-assignee.yml
@@ -1,0 +1,18 @@
+name: Mirror reviewer to assignee
+
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  assign:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      pull-requests: write
+    steps:
+      - if: github.event.requested_reviewer.login != ''
+        run: gh pr edit "$PR" --add-assignee "$REVIEWER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+          REVIEWER: ${{ github.event.requested_reviewer.login }}


### PR DESCRIPTION
Auto-assigns a requested reviewer as an assignee on `review_requested`, so PRs awaiting a person surface in their assigned list. Team review requests are skipped (no `.login`). Uses the org-standard `blacksmith-2vcpu-ubuntu-2404` runner.

Part of the org-wide reviewer-mirror rollout; also added as a `.github` workflow template.