### PR TITLE
Fix mirror-reviewer-to-assignee: use REST assignees endpoint

### DIFF
--- a/.github/workflows/mirror-reviewer-to-assignee.yml
+++ b/.github/workflows/mirror-reviewer-to-assignee.yml
@@ -11,8 +11,9 @@ jobs:
       pull-requests: write
     steps:
       - if: github.event.requested_reviewer.login != ''
-        run: gh pr edit "$PR" --add-assignee "$REVIEWER"
+        run: gh api --method POST "repos/$REPO/issues/$PR/assignees" -f "assignees[]=$REVIEWER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
           REVIEWER: ${{ github.event.requested_reviewer.login }}


### PR DESCRIPTION
The merged workflow used `gh pr edit --add-assignee`, which resolves assignees via a capped GraphQL suggested-users lookup and fails with `not found` for valid assignees in large orgs (seen on tray-cdk-deployment#294). Switch to `POST /issues/{n}/assignees`, which assigns by login directly and silently ignores non-assignable users.